### PR TITLE
Typo

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -68,7 +68,7 @@ function php-fpm() {
   } | tee /etc/php7/php-fpm.d/zz-docker.conf
 
   {
-        echo 'max_executionn_time=300'
+        echo 'max_execution_time=300'
         echo 'memory_limit={{PHP_MEMORY_LIMIT}}M'
         echo 'error_reporting=1'
         echo 'display_errors=0'


### PR DESCRIPTION
Need more variables in .env file.
        echo 'max_execution_time=300'
        echo 'upload_max_filesize=50M'
        echo 'post_max_size=50M'